### PR TITLE
LINE側のドメイン変更に対応

### DIFF
--- a/LineMessaging/LineConstants.cs
+++ b/LineMessaging/LineConstants.cs
@@ -5,5 +5,6 @@ namespace LineMessaging
     internal static class LineConstants
     {
         internal static readonly Uri BaseUri = new Uri("https://api.line.me/");
+        internal static readonly Uri BaseDataUri = new Uri("https://api-data.line.me/");
     }
 }

--- a/LineMessaging/LineMessagingClient.cs
+++ b/LineMessaging/LineMessagingClient.cs
@@ -17,6 +17,11 @@ namespace LineMessaging
             BaseAddress = LineConstants.BaseUri,
             Timeout = TimeSpan.FromSeconds(10)
         };
+        private static readonly HttpClient HttpDataClient = new HttpClient
+        {
+            BaseAddress = LineConstants.BaseDataUri,
+            Timeout = TimeSpan.FromSeconds(10)
+        };
 
         private readonly AuthenticationHeaderValue accessTokenHeaderValue;
 
@@ -68,7 +73,7 @@ namespace LineMessaging
                 HttpResponseMessage response;
                 try
                 {
-                    response = await HttpClient.SendAsync(message);
+                    response = await HttpDataClient.SendAsync(message);
                 }
                 catch (TaskCanceledException)
                 {


### PR DESCRIPTION
LINE Messaging APIの一部のエンドポイントのドメイン名が「api.line.me」から「api-data.line.me」に変更された関係で画像取得が出来なくなってました。
https://developers.line.biz/ja/docs/messaging-api/release-notes/#20210121-domain-name

